### PR TITLE
Cors enabling

### DIFF
--- a/.env.examples
+++ b/.env.examples
@@ -1,6 +1,17 @@
+# OPEN_WEATHER_MAP API KEYS
+
 OPEN_WEATHER_MAP_API_KEY=<get your from openweathermap.com>
+
+# TROPOSPHERE API KEYS
+
 TROPOSPHERE_API_KEY=<get your from troposphere.io>
+
+# MONGODB ACCESS DATA
 
 MONGODB_USER=<your username for mongodb instance>
 MONGODB_PWD=<your password for mongodb instance>
 MONGODB_URI=<your uri for mongodb instance>
+
+# CLIENT DATA (Used by Cors Options)
+
+CLIENT_URL=<your_client_url>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Server for Weather Vortex Project.
 
-** Table of contents **
+**Table of contents**
 
 - [How to](#how-to)
   - [Build](#build)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "axios": "^0.21.1",
         "bcrypt": "^5.0.1",
         "cookie-parser": "^1.4.5",
+        "cors": "^2.8.5",
         "crypto": "^1.0.1",
         "express": "^4.17.1",
         "jsonwebtoken": "^8.5.1",
@@ -1320,6 +1321,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -5534,6 +5547,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "axios": "^0.21.1",
     "bcrypt": "^5.0.1",
     "cookie-parser": "^1.4.5",
+    "cors": "^2.8.5",
     "crypto": "^1.0.1",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-vortex-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Server for Weather Vortex Project.",
   "main": "src/index.js",
   "scripts": {

--- a/src/config/cors.config.js
+++ b/src/config/cors.config.js
@@ -16,29 +16,36 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-/*
-
-# Cors support
-
-Vue.axios on client application block requests from domains others than this. If you wanna run this server and use cors restriction policies, set properly your .env file. If left empty, allow any domain.
-
-*/
+"use strict";
 
 const cors = require("cors");
 
+/*
+## Cors support
+
+Read Origin from env vars or allow anyone.
+
+## Motivations
+
+Client applications block requests from domains others than this. If you wanna run this server using cors restriction policies, set properly your .env file. If left empty, allow any origin to make request to any route.
+
+*/
 const origin = process.env.CLIENT_URL || "*";
 
-const corsOptions = {
+/**
+ * Cors options configured for this project.
+ */
+const options = {
   origin,
-  optionsSuccessStatus: 200,
+  optionsSuccessStatus: 200, // some legacy browsers (IE11, various SmartTVs) choke on 204
 };
 
 /**
- * 
+ * Add [Cors Middleware](http://expressjs.com/en/resources/middleware/cors.html) and configure it.
  * @param {Express} app Express application to configure.
  */
-const configureCors = (app) => {
-  app.use(cors(corsOptions));
+const configure = (app) => {
+  app.use(cors(options));
 };
 
-module.exports = 
+module.exports = { configure, options };

--- a/src/config/cors.config.js
+++ b/src/config/cors.config.js
@@ -1,0 +1,44 @@
+/*
+    Web server for Weather Vortex project.
+    Copyright (C) 2021  Tentoni Daniele
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+
+# Cors support
+
+Vue.axios on client application block requests from domains others than this. If you wanna run this server and use cors restriction policies, set properly your .env file. If left empty, allow any domain.
+
+*/
+
+const cors = require("cors");
+
+const origin = process.env.CLIENT_URL || "*";
+
+const corsOptions = {
+  origin,
+  optionsSuccessStatus: 200,
+};
+
+/**
+ * 
+ * @param {Express} app Express application to configure.
+ */
+const configureCors = (app) => {
+  app.use(cors(corsOptions));
+};
+
+module.exports = 

--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,11 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+const { configureCors } = require("./config/cors.config");
+const cookieParser = require("cookie-parser");
 const express = require("express");
 const mongoose = require("mongoose");
-const cookieParser = require("cookie-parser");
+
 const db = require("./config/config").get(process.env.NODE_ENV);
 
 //database connection-> ps: l'ho modificato per tenere nascosto il link al database
@@ -33,10 +35,11 @@ mongoConnection
   .catch((err) => console.error(err));
 
 const app = express();
+
+configureCors(app);
 app.use(express.urlencoded({ extended: false }));
 app.use(express.json());
 app.use(cookieParser());
-app.use(express.json());
 
 app.get("/", (req, res) => {
   res.status(200).json({ result: "ok" });

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-const { configureCors } = require("./config/cors.config");
+const cors = require("./config/cors.config");
 const cookieParser = require("cookie-parser");
 const express = require("express");
 const mongoose = require("mongoose");
@@ -36,7 +36,7 @@ mongoConnection
 
 const app = express();
 
-configureCors(app);
+cors.configure(app);
 app.use(express.urlencoded({ extended: false }));
 app.use(express.json());
 app.use(cookieParser());
@@ -64,7 +64,10 @@ app.listen(port, () => {
     "Weather Vortex  Copyright (C) 2021  Lirussi Igor, Tentoni Daniele, Zandoli Silvia"
   );
   console.log("This program comes with ABSOLUTELY NO WARRANTY\n");
-  console.log("Application running on http://localhost:12000");
+
+  console.log("Application running on http://localhost:12000\n");
+
+  console.log("Weather Vortex is running those CORS options:", cors.options);
 });
 
 // Export app to use it in unit testing.


### PR DESCRIPTION
# Cors enabling

We have discussed in #31 about cors policies. This pr add a new cors policies that allow all origins by default, leaving to admins the capability to change this rule and set their custom origins. In our production environment, we'll leave this all-allowed policy.

Merging this pr will close #31 .

After merging this, we have to deploy a new version to Heroku.