### PR TITLE
fix cronjob UTC time

### DIFF
--- a/.github/workflows/cronjob.yml
+++ b/.github/workflows/cronjob.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Trigger this workflow each day at midnight.
-    - cron:  '0 02 * * *' #UTC TIME, Italy is generally -2h
+    - cron:  '0 22 * * *' #UTC TIME, Italy is generally +2h
 
 jobs:
   # Trigger a direct telegram notification.


### PR DESCRIPTION
Time 00:00 UTC corresponds at the moment at 2 am in Italy, to send messages at midnight it has to be fixed