### PR TITLE
Add the new dependabot config file.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    reviewers:
+      - "igor-lirussi"
+      - "Daniele-Tentoni"
+      - "silviazandoli"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "igor-lirussi"
+      - "Daniele-Tentoni"
+      - "silviazandoli"


### PR DESCRIPTION
Attiva le richieste di pull request automatiche da Dependabot una volta alla settimana (`interval: "weekly"`) per un massimo di una pull request. Ho scelto questi valori perché ci consentono di lavorare meglio sul progetto preoccupandoci di più di quello che dobbiamo fare realmente. Tanto per adesso è un progetto con poche dipendenze che in generale non ha bisogno di molta manutenzione.

Il controllo viene effettuato sia su **NPM** (`package-ecosystem: "npm"`) che sulle **Github Actions** (`package-ecosystem: "github-actions"`).

Ad ogni pull request veniamo automaticamente assegnati come reviewers (`reviewers: - "igor-lirussi" - "Daniele-Tentoni" - "silviazandoli"`).