### PR TITLE
Add condition for Open Weather Map rains.

### DIFF
--- a/src/storages/openweathermap.storage.js
+++ b/src/storages/openweathermap.storage.js
@@ -51,9 +51,13 @@ const mapFields = (forecast) => {
 
   // In Node 14.x we can write as `forecast.rain?.3h ?? 0`.
   if (typeof forecast.rain === "object") {
-    forecast.rain = forecast.rain["1h"];
+    forecast.rain = forecast.rain["1h"]
+      ? forecast.rain["1h"]
+      : forecast.rain["3h"]
+      ? forecast.rain["3h"]
+      : "n.d.";
   } else {
-    forecast.rain = 0;
+    forecast.rain = "n.d.";
   }
 
   if (typeof forecast.snow === "object") {


### PR DESCRIPTION
Open Weather Map rains value are given with a 1h or 3h timelapse that as to be managed and standardized in order to give to client app an uniform value to other weather providers.