### PR TITLE
Geolocation forecasts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weather-vortex-server",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "weather-vortex-server",
-      "version": "0.7.4",
+      "version": "0.8.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "axios": "^0.22.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weather-vortex-server",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "weather-vortex-server",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "axios": "^0.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-vortex-server",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "description": "Server for Weather Vortex Project.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-vortex-server",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Server for Weather Vortex Project.",
   "main": "src/index.js",
   "scripts": {

--- a/src/controllers/forecast.controller.js
+++ b/src/controllers/forecast.controller.js
@@ -68,7 +68,7 @@ const getCurrentForecastsWithIo = async (socket, locality) => {
         console.log("Open Weather Map socket error:", error);
         socket.emit(
           "forecast_error",
-          { provider: "OpenWeatherMap" },
+          { provider: "Open Weather Map" },
           { error }
         );
       });

--- a/src/controllers/forecast.controller.js
+++ b/src/controllers/forecast.controller.js
@@ -165,6 +165,11 @@ const emitCurrentForecasts = async (latitude, longitude, stations, socket) => {
         socket.emit("forecast_error", { provider: "Troposphere" }, { error });
       });
 
+    if (!stations) {
+      // If there's no stations, return here.
+      return;
+    }
+
     // Stations pending requests.
     stations.map((s) => {
       const provider = new StationProvider(s.url, s.authKey, s.name);

--- a/src/routes/forecasts.routes.js
+++ b/src/routes/forecasts.routes.js
@@ -50,7 +50,13 @@ const configRouter = (app, io) => {
       if (arg.locality) {
         controller.getCurrentForecastsWithIo(socket, arg.locality);
       } else if (arg.latitude && arg.longitude) {
-        controller.getCurrentGeolocationForecastWithIo(socket, arg.locality);
+        controller.getCurrentGeolocationForecastWithIo(
+          socket,
+          arg.latitude,
+          arg.longitude
+        );
+      } else {
+        // Emit corrupted packet error.
       }
     });
 
@@ -59,7 +65,13 @@ const configRouter = (app, io) => {
       if (arg.locality) {
         controller.getThreeDaysForecastsWithIo(socket, arg.locality);
       } else if (arg.latitude && arg.longitude) {
-        controller.getThreeDaysGeolocationForecastWithIo(socket, arg.locality);
+        controller.getThreeDaysGeolocationForecastWithIo(
+          socket,
+          arg.latitude,
+          arg.longitude
+        );
+      } else {
+        // Emit corrupted packet error.
       }
     });
 

--- a/src/routes/forecasts.routes.js
+++ b/src/routes/forecasts.routes.js
@@ -47,12 +47,20 @@ const configRouter = (app, io) => {
 
     socket.on("current", (arg) => {
       console.log("Received a current forecast request with arg:", arg);
-      controller.getCurrentForecastsWithIo(socket, arg.locality);
+      if (arg.locality) {
+        controller.getCurrentForecastsWithIo(socket, arg.locality);
+      } else if (arg.latitude && arg.longitude) {
+        controller.getCurrentGeolocationForecastWithIo(socket, arg.locality);
+      }
     });
 
     socket.on("threedays", (arg) => {
       console.log("Received a three days forecast request with arg: ", arg);
-      controller.getThreeDaysForecastsWithIo(socket, arg.locality);
+      if (arg.locality) {
+        controller.getThreeDaysForecastsWithIo(socket, arg.locality);
+      } else if (arg.latitude && arg.longitude) {
+        controller.getThreeDaysGeolocationForecastWithIo(socket, arg.locality);
+      }
     });
 
     socket.on("disconnect", () => {
@@ -65,6 +73,15 @@ const configRouter = (app, io) => {
 
   router
     .get("/notify", controller.notify)
+    .get(
+      "/:latitude,:longitude/threedays",
+      controller.getThreeDaysGeolocationForecast
+    )
+    .get(
+      "/:latitude,:longitude/current",
+      controller.getCurrentGeolocationForecast
+    )
+    .get("/:latitude,:longitude", controller.getThreeDaysGeolocationForecast)
     .get("/:locality/threedays", controller.getThreeDaysForecasts)
     .get("/:locality/current", controller.getCurrentForecasts)
     .get("/:locality", controller.getThreeDaysForecasts);

--- a/test/forecasts.test.js
+++ b/test/forecasts.test.js
@@ -48,48 +48,95 @@ describe("GET forecasts for Cesena", () => {
       expect(result).to.have.a.nested.property("error.text");
     });
 
-    it("responds with successful result", async () => {
-      const result = await request(app)
-        .get(base_url + "/Cesena")
-        .set("content-type", "application/json")
-        .set("Accept", "application/json");
+    describe("responds with successful result", () => {
+      it("with simple current forecast request by location", async () => {
+        const result = await request(app)
+          .get(base_url + "/Cesena")
+          .set("content-type", "application/json")
+          .set("Accept", "application/json");
 
-      expect(result).to.have.status(200);
-      expect(result).to.be.an("object", "We expect that result is an object");
-      const body = result.body;
-      expect(result.body).to.have.a.property("tro");
-      expect(body).to.have.a.property("owm");
-      const tro = body.tro;
-      expect(tro)
-        .to.be.an("object")
-        .to.have.a.property("provider", "Troposphere");
-      expect(tro).to.have.a.property("forecast").to.be.an("array");
-      tro.forecast.forEach((each) => {
-        expect(each).to.have.a.property("time").to.be.a("string");
-        expect(each)
+        expect(result).to.have.status(200);
+        expect(result).to.be.an("object", "We expect that result is an object");
+        const body = result.body;
+        expect(result.body).to.have.a.property("tro");
+        expect(body).to.have.a.property("owm");
+        const tro = body.tro;
+        expect(tro)
           .to.be.an("object")
-          .to.have.a.property("weatherDescription")
-          .to.be.a("string").to.be.not.null;
-      });
-      const owm = body.owm;
-      expect(owm)
-        .to.be.an("object")
-        .to.have.a.property("provider", "Open Weather Map");
-      expect(owm).to.have.a.property("forecast").to.be.an("array");
-      owm.forecast.forEach((each, index) => {
-        expect(each)
-          .to.have.a.property("time")
-          .to.be.equals(
-            tro.forecast[index].time,
-            "Times between providers are not equals"
-          );
-        expect(each)
+          .to.have.a.property("provider", "Troposphere");
+        expect(tro).to.have.a.property("forecast").to.be.an("array");
+        tro.forecast.forEach((each) => {
+          expect(each).to.have.a.property("time").to.be.a("string");
+          expect(each)
+            .to.be.an("object")
+            .to.have.a.property("weatherDescription")
+            .to.be.a("string").to.be.not.null;
+        });
+        const owm = body.owm;
+        expect(owm)
           .to.be.an("object")
-          .to.have.a.property("weatherDescription")
-          .to.be.a("string").to.be.not.null;
+          .to.have.a.property("provider", "Open Weather Map");
+        expect(owm).to.have.a.property("forecast").to.be.an("array");
+        owm.forecast.forEach((each, index) => {
+          expect(each)
+            .to.have.a.property("time")
+            .to.be.equals(
+              tro.forecast[index].time,
+              "Times between providers are not equals"
+            );
+          expect(each)
+            .to.be.an("object")
+            .to.have.a.property("weatherDescription")
+            .to.be.a("string").to.be.not.null;
+        });
+      }, 2) // Retry at least one more time after fail
+        .timeout(10000); // This test need more time.
+
+      it("with three days forecast request by location", async () => {
+        const result = await request(app)
+          .get(base_url + "/Cesena/threedays")
+          .set("content-type", "application/json")
+          .set("Accept", "application/json");
+
+        expect(result).to.have.status(200);
       });
-    }, 2) // Retry at least one more time after fail
-      .timeout(10000); // This test need more time.
+
+      it("with current forecast request by location", async () => {
+        const result = await request(app)
+          .get(base_url + "/Cesena/current")
+          .set("content-type", "application/json")
+          .set("Accept", "application/json");
+
+        expect(result).to.have.status(200);
+      });
+
+      it("with simple three days forecast request by geolocation", async () => {
+        const result = await request(app)
+          .get(base_url + "/14,15")
+          .set("content-type", "application/json")
+          .set("Accept", "application/json");
+
+        expect(result).to.have.status(200);
+      });
+
+      it("with current forecast request by geolocation", async () => {
+        const result = await request(app)
+          .get(base_url + "/14,15/current")
+          .set("content-type", "application/json")
+          .set("Accept", "application/json");
+
+        expect(result).to.have.status(200);
+      });
+
+      it("with three days forecast request by geolocation", async () => {
+        const result = await request(app)
+          .get(base_url + "/14,15/threedays")
+          .set("content-type", "application/json")
+          .set("Accept", "application/json");
+
+        expect(result).to.have.status(200);
+      });
+    });
   });
 
   describe("With a failure", () => {


### PR DESCRIPTION
Now server can serve requests of forecasts by geolocation position expressed as `forecasts/:latitude,:longitude`.